### PR TITLE
Agrego compilación no interactiva opcional al esqueleto de lab shell

### DIFF
--- a/shell/Makefile
+++ b/shell/Makefile
@@ -1,6 +1,12 @@
 CFLAGS := -ggdb3 -O2 -Wall -Wextra -std=gnu11
 CFLAGS += -Wmissing-prototypes
 
+# To force build a test shell run:
+#     make -B -e SHELL_TEST=true
+ifdef SHELL_TEST
+	CFLAGS += -D SHELL_NO_COLORS -D SHELL_NO_INTERACTIVE
+endif
+
 EXEC := sh
 SRCS := $(wildcard *.c)
 OBJS := $(SRCS:%.c=%.o)
@@ -21,4 +27,4 @@ format: .clang-files .clang-format
 clean:
 	rm -rf $(EXEC) *.o core vgcore.*
 
-.PHONY: all clean format run valgrind
+.PHONY: all clean format run valgrind sh

--- a/shell/Makefile
+++ b/shell/Makefile
@@ -27,4 +27,4 @@ format: .clang-files .clang-format
 clean:
 	rm -rf $(EXEC) *.o core vgcore.*
 
-.PHONY: all clean format run valgrind sh
+.PHONY: all clean format run valgrind

--- a/shell/defs.h
+++ b/shell/defs.h
@@ -15,10 +15,16 @@
 #include <sys/wait.h>
 #include <sys/types.h>
 
+#ifndef SHELL_NO_COLORS
 // color scape strings
 #define COLOR_BLUE "\x1b[34m"
 #define COLOR_RED "\x1b[31m"
 #define COLOR_RESET "\x1b[0m"
+#else
+#define COLOR_BLUE ""
+#define COLOR_RED ""
+#define COLOR_RESET ""
+#endif
 
 #define END_STRING '\0'
 #define END_LINE '\n'

--- a/shell/printstatus.c
+++ b/shell/printstatus.c
@@ -8,34 +8,34 @@ print_status_info(struct cmd *cmd)
 		return;
 
 	if (WIFEXITED(status)) {
-        #ifndef SHELL_NO_INTERACTIVE
+#ifndef SHELL_NO_INTERACTIVE
 		fprintf(stdout,
 		        "%s	Program: [%s] exited, status: %d %s\n",
 		        COLOR_BLUE,
 		        cmd->scmd,
 		        WEXITSTATUS(status),
 		        COLOR_RESET);
-        #endif
+#endif
 		status = WEXITSTATUS(status);
 	} else if (WIFSIGNALED(status)) {
-        #ifndef SHELL_NO_INTERACTIVE
+#ifndef SHELL_NO_INTERACTIVE
 		fprintf(stdout,
 		        "%s	Program: [%s] killed, status: %d %s\n",
 		        COLOR_BLUE,
 		        cmd->scmd,
 		        -WTERMSIG(status),
 		        COLOR_RESET);
-        #endif
+#endif
 		status = -WTERMSIG(status);
 	} else if (WTERMSIG(status)) {
-        #ifndef SHELL_NO_INTERACTIVE
+#ifndef SHELL_NO_INTERACTIVE
 		fprintf(stdout,
 		        "%s	Program: [%s] stopped, status: %d %s\n",
 		        COLOR_BLUE,
 		        cmd->scmd,
 		        -WSTOPSIG(status),
 		        COLOR_RESET);
-        #endif
+#endif
 		status = -WSTOPSIG(status);
 	}
 }
@@ -44,7 +44,7 @@ print_status_info(struct cmd *cmd)
 void
 print_back_info(struct cmd *back)
 {
-    #ifndef SHELL_NO_INTERACTIVE
+#ifndef SHELL_NO_INTERACTIVE
 	fprintf(stdout, "%s  [PID=%d] %s\n", COLOR_BLUE, back->pid, COLOR_RESET);
-    #endif
+#endif
 }

--- a/shell/printstatus.c
+++ b/shell/printstatus.c
@@ -8,30 +8,34 @@ print_status_info(struct cmd *cmd)
 		return;
 
 	if (WIFEXITED(status)) {
+        #ifndef SHELL_NO_INTERACTIVE
 		fprintf(stdout,
 		        "%s	Program: [%s] exited, status: %d %s\n",
 		        COLOR_BLUE,
 		        cmd->scmd,
 		        WEXITSTATUS(status),
 		        COLOR_RESET);
+        #endif
 		status = WEXITSTATUS(status);
-
 	} else if (WIFSIGNALED(status)) {
+        #ifndef SHELL_NO_INTERACTIVE
 		fprintf(stdout,
 		        "%s	Program: [%s] killed, status: %d %s\n",
 		        COLOR_BLUE,
 		        cmd->scmd,
 		        -WTERMSIG(status),
 		        COLOR_RESET);
+        #endif
 		status = -WTERMSIG(status);
-
 	} else if (WTERMSIG(status)) {
+        #ifndef SHELL_NO_INTERACTIVE
 		fprintf(stdout,
 		        "%s	Program: [%s] stopped, status: %d %s\n",
 		        COLOR_BLUE,
 		        cmd->scmd,
 		        -WSTOPSIG(status),
 		        COLOR_RESET);
+        #endif
 		status = -WSTOPSIG(status);
 	}
 }
@@ -40,5 +44,7 @@ print_status_info(struct cmd *cmd)
 void
 print_back_info(struct cmd *back)
 {
+    #ifndef SHELL_NO_INTERACTIVE
 	fprintf(stdout, "%s  [PID=%d] %s\n", COLOR_BLUE, back->pid, COLOR_RESET);
+    #endif
 }

--- a/shell/readline.c
+++ b/shell/readline.c
@@ -10,10 +10,10 @@ read_line(const char *promt)
 {
 	int i = 0, c = 0;
 
-    #ifndef SHELL_NO_INTERACTIVE
+#ifndef SHELL_NO_INTERACTIVE
 	fprintf(stdout, "%s %s %s\n", COLOR_RED, promt, COLOR_RESET);
 	fprintf(stdout, "%s", "$ ");
-    #endif
+#endif
 
 	memset(buffer, 0, BUFLEN);
 

--- a/shell/readline.c
+++ b/shell/readline.c
@@ -10,8 +10,10 @@ read_line(const char *promt)
 {
 	int i = 0, c = 0;
 
+    #ifndef SHELL_NO_INTERACTIVE
 	fprintf(stdout, "%s %s %s\n", COLOR_RED, promt, COLOR_RESET);
 	fprintf(stdout, "%s", "$ ");
+    #endif
 
 	memset(buffer, 0, BUFLEN);
 


### PR DESCRIPTION
Agrego algunas directivas para permitir la compilación no interactiva. Modifico Makefile para permitir compilar con `-e SHELL_TEST=true`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fisop/labs/10)
<!-- Reviewable:end -->
