### PR TITLE
feat: require isatty(1) in the absence of SHELL_NO_INTERACTIVE

### DIFF
--- a/shell/printstatus.c
+++ b/shell/printstatus.c
@@ -1,43 +1,40 @@
+#include <unistd.h>
+
 #include "printstatus.h"
 
 // prints information of process' status
 void
 print_status_info(struct cmd *cmd)
 {
+	const char *action;
+
 	if (strlen(cmd->scmd) == 0 || cmd->type == PIPE)
 		return;
 
 	if (WIFEXITED(status)) {
-#ifndef SHELL_NO_INTERACTIVE
-		fprintf(stdout,
-		        "%s	Program: [%s] exited, status: %d %s\n",
-		        COLOR_BLUE,
-		        cmd->scmd,
-		        WEXITSTATUS(status),
-		        COLOR_RESET);
-#endif
+		action = "exited";
 		status = WEXITSTATUS(status);
 	} else if (WIFSIGNALED(status)) {
-#ifndef SHELL_NO_INTERACTIVE
-		fprintf(stdout,
-		        "%s	Program: [%s] killed, status: %d %s\n",
-		        COLOR_BLUE,
-		        cmd->scmd,
-		        -WTERMSIG(status),
-		        COLOR_RESET);
-#endif
+		action = "killed";
 		status = -WTERMSIG(status);
 	} else if (WTERMSIG(status)) {
+		action = "stopped";
+		status = -WSTOPSIG(status);
+	} else {
+		return;
+	}
+
 #ifndef SHELL_NO_INTERACTIVE
+	if (isatty(1)) {
 		fprintf(stdout,
-		        "%s	Program: [%s] stopped, status: %d %s\n",
+		        "%s	Program: [%s] %s, status: %d %s\n",
 		        COLOR_BLUE,
 		        cmd->scmd,
-		        -WSTOPSIG(status),
+		        action,
+		        status,
 		        COLOR_RESET);
-#endif
-		status = -WSTOPSIG(status);
 	}
+#endif
 }
 
 // prints info when a background process is spawned
@@ -45,6 +42,8 @@ void
 print_back_info(struct cmd *back)
 {
 #ifndef SHELL_NO_INTERACTIVE
-	fprintf(stdout, "%s  [PID=%d] %s\n", COLOR_BLUE, back->pid, COLOR_RESET);
+	if (isatty(1)) {
+		fprintf(stdout, "%s  [PID=%d] %s\n", COLOR_BLUE, back->pid, COLOR_RESET);
+	}
 #endif
 }

--- a/shell/readline.c
+++ b/shell/readline.c
@@ -1,3 +1,5 @@
+#include <unistd.h>
+
 #include "defs.h"
 #include "readline.h"
 
@@ -11,8 +13,10 @@ read_line(const char *prompt)
 	int i = 0, c = 0;
 
 #ifndef SHELL_NO_INTERACTIVE
-	fprintf(stdout, "%s %s %s\n", COLOR_RED, prompt, COLOR_RESET);
-	fprintf(stdout, "%s", "$ ");
+	if (isatty(1)) {
+		fprintf(stdout, "%s %s %s\n", COLOR_RED, prompt, COLOR_RESET);
+		fprintf(stdout, "%s", "$ ");
+	}
 #endif
 
 	memset(buffer, 0, BUFLEN);


### PR DESCRIPTION
-----

Se compartieron en Discord algunos outputs del script de corrección que claramente se habían compilado sin SHELL_NO_INTERACTIVE. Me parece práctico intentar evitar spurious output mirando el device type de stdout.

Solo una idea!